### PR TITLE
feat: add streams dashboard page

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -6,6 +6,7 @@ import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import LightModeIcon from "@mui/icons-material/LightMode";
 import MenuIcon from "@mui/icons-material/Menu";
 import PeopleAltIcon from "@mui/icons-material/PeopleAlt";
+import SensorsIcon from "@mui/icons-material/Sensors";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import {
   AppBar,
@@ -188,6 +189,11 @@ export default function Navbar({ children, renderMain = true }: NavbarProps) {
             text="Watch"
             href="/watch"
             icon={<VisibilityIcon />}
+          />
+          <DrawerListItem
+            text="Streams"
+            href="/streams"
+            icon={<SensorsIcon />}
           />
           <DrawerListItem
             text="Help & FAQ"

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WatchRouteImport } from './routes/watch'
+import { Route as StreamsRouteImport } from './routes/streams'
 import { Route as QueryRouteImport } from './routes/query'
 import { Route as FaqRouteImport } from './routes/faq'
 import { Route as AboutRouteImport } from './routes/about'
@@ -18,6 +19,11 @@ import { Route as IndexRouteImport } from './routes/index'
 const WatchRoute = WatchRouteImport.update({
   id: '/watch',
   path: '/watch',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StreamsRoute = StreamsRouteImport.update({
+  id: '/streams',
+  path: '/streams',
   getParentRoute: () => rootRouteImport,
 } as any)
 const QueryRoute = QueryRouteImport.update({
@@ -46,6 +52,7 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/faq': typeof FaqRoute
   '/query': typeof QueryRoute
+  '/streams': typeof StreamsRoute
   '/watch': typeof WatchRoute
 }
 export interface FileRoutesByTo {
@@ -53,6 +60,7 @@ export interface FileRoutesByTo {
   '/about': typeof AboutRoute
   '/faq': typeof FaqRoute
   '/query': typeof QueryRoute
+  '/streams': typeof StreamsRoute
   '/watch': typeof WatchRoute
 }
 export interface FileRoutesById {
@@ -61,14 +69,15 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/faq': typeof FaqRoute
   '/query': typeof QueryRoute
+  '/streams': typeof StreamsRoute
   '/watch': typeof WatchRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/about' | '/faq' | '/query' | '/watch'
+  fullPaths: '/' | '/about' | '/faq' | '/query' | '/streams' | '/watch'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/about' | '/faq' | '/query' | '/watch'
-  id: '__root__' | '/' | '/about' | '/faq' | '/query' | '/watch'
+  to: '/' | '/about' | '/faq' | '/query' | '/streams' | '/watch'
+  id: '__root__' | '/' | '/about' | '/faq' | '/query' | '/streams' | '/watch'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -76,6 +85,7 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   FaqRoute: typeof FaqRoute
   QueryRoute: typeof QueryRoute
+  StreamsRoute: typeof StreamsRoute
   WatchRoute: typeof WatchRoute
 }
 
@@ -86,6 +96,13 @@ declare module '@tanstack/react-router' {
       path: '/watch'
       fullPath: '/watch'
       preLoaderRoute: typeof WatchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/streams': {
+      id: '/streams'
+      path: '/streams'
+      fullPath: '/streams'
+      preLoaderRoute: typeof StreamsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/query': {
@@ -124,6 +141,7 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   FaqRoute: FaqRoute,
   QueryRoute: QueryRoute,
+  StreamsRoute: StreamsRoute,
   WatchRoute: WatchRoute,
 }
 export const routeTree = rootRouteImport

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -119,15 +119,16 @@ function StreamSchema({ streamInfo }: { streamInfo: StreamInfo }) {
       component="pre"
       sx={{
         fontFamily: '"Roboto Mono", monospace',
-        fontSize: "0.75rem",
+        fontSize: "0.7rem",
         bgcolor: "background.default",
-        p: 1.5,
+        p: 1,
         borderRadius: 1,
         border: 1,
         borderColor: "divider",
         overflow: "auto",
+        maxHeight: 120,
         m: 0,
-        lineHeight: 1.8,
+        lineHeight: 1.6,
       }}
     >
       {streamInfo.events_info.map((event, i) => (
@@ -258,13 +259,13 @@ function StreamDetailRow({
   return (
     <TableRow>
       <TableCell colSpan={5} sx={{ py: 0, px: 0 }}>
-        <Box sx={{ p: 3, bgcolor: "action.hover" }}>
+        <Box sx={{ p: 2, bgcolor: "action.hover" }}>
           <Box
             sx={{
               display: "grid",
               gridTemplateColumns: "1fr 1fr",
-              gap: 3,
-              mb: 2,
+              gap: 2,
+              mb: 1,
             }}
           >
             {/* Left: About + Schema */}

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -259,17 +259,16 @@ function StreamDetailRow({
   return (
     <TableRow>
       <TableCell colSpan={5} sx={{ py: 0, px: 0 }}>
-        <Box sx={{ p: 2, bgcolor: "action.hover" }}>
+        <Box sx={{ px: 2, py: 1.5, bgcolor: "action.hover" }}>
           <Box
             sx={{
-              display: "grid",
-              gridTemplateColumns: schemaInfo ? "1fr 1fr" : "1fr",
+              display: "flex",
               gap: 2,
               mb: 1,
             }}
           >
             {/* Left: About + Schema */}
-            <Box>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
               {schemaInfo && (
                 <>
                   <Typography
@@ -304,7 +303,7 @@ function StreamDetailRow({
 
             {/* Right: FAQ */}
             {schemaInfo && (
-              <Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography
                   variant="overline"
                   color="text.secondary"

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -383,14 +383,22 @@ function StreamTable({
 
   return (
     <TableContainer component={Paper} variant="outlined">
-      <Table size="small">
+      <Table size="small" sx={{ tableLayout: "fixed" }}>
         <TableHead>
           <TableRow>
             <TableCell>Stream</TableCell>
-            <TableCell align="right">Events/sec</TableCell>
-            <TableCell align="right">Total Events</TableCell>
-            <TableCell align="right">Last Event</TableCell>
-            <TableCell align="center">Status</TableCell>
+            <TableCell align="right" sx={{ width: 120 }}>
+              Events/sec
+            </TableCell>
+            <TableCell align="right" sx={{ width: 130 }}>
+              Total Events
+            </TableCell>
+            <TableCell align="right" sx={{ width: 120 }}>
+              Last Event
+            </TableCell>
+            <TableCell align="center" sx={{ width: 100 }}>
+              Status
+            </TableCell>
           </TableRow>
         </TableHead>
         <TableBody>

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -324,9 +324,10 @@ function StreamTable({
               {expandedStream === stream.name && (
                 <StreamDetailRow
                   stream={stream}
-                  streamInfo={streamsInfo.find(
-                    (si) =>
-                      si.name.toLowerCase() === stream.name.toLowerCase(),
+                  streamInfo={streamsInfo.find((si) =>
+                    si.events_info.some((e) =>
+                      stream.event_types.includes(e.name),
+                    ),
                   )}
                 />
               )}

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -1,6 +1,11 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
-import { getStreamStats, getQueryInfos, getStreamsInfo } from "@/utils/api";
+import {
+  getStreamStats,
+  getQueryInfos,
+  getStreamsInfo,
+  getWsBaseUrl,
+} from "@/utils/api";
 import { getSchemaInfo, type FAQItem } from "@/data/faq";
 import type { StreamInfo, StreamStats, StreamType } from "@/types";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
@@ -11,6 +16,7 @@ import {
   Box,
   Chip,
   Container,
+  Divider,
   Paper,
   Table,
   TableBody,
@@ -20,7 +26,7 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import { Fragment, useState } from "react";
+import { Fragment, useEffect, useRef, useState } from "react";
 
 export const Route = createFileRoute("/streams")({
   component: StreamsPage,
@@ -148,6 +154,97 @@ function StreamSchema({ streamInfo }: { streamInfo: StreamInfo }) {
   );
 }
 
+const MAX_EVENTS = 50;
+
+type RawEvent = {
+  event_type: string;
+  attributes: (string | number | boolean)[];
+};
+
+function LiveEventFeed({ streamName }: { streamName: string }) {
+  const [events, setEvents] = useState<RawEvent[]>([]);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    const wsUrl = getWsBaseUrl() + "/stream/events/" + streamName;
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onmessage = (msg) => {
+      const event = JSON.parse(msg.data as string) as RawEvent;
+      setEvents((prev) => {
+        const next = [event, ...prev];
+        if (next.length > MAX_EVENTS) next.length = MAX_EVENTS;
+        return next;
+      });
+    };
+
+    return () => {
+      ws.close();
+      wsRef.current = null;
+    };
+  }, [streamName]);
+
+  return (
+    <Box
+      sx={{
+        maxHeight: 240,
+        overflow: "auto",
+        fontFamily: '"Roboto Mono", monospace',
+        fontSize: "0.7rem",
+        border: 1,
+        borderColor: "divider",
+        borderRadius: 1,
+        bgcolor: "background.default",
+      }}
+    >
+      {events.length === 0 ? (
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ p: 2, textAlign: "center", fontFamily: "inherit" }}
+        >
+          Waiting for events...
+        </Typography>
+      ) : (
+        events.map((event, i) => (
+          <Box
+            key={i}
+            sx={{
+              px: 1.5,
+              py: 0.5,
+              borderBottom: 1,
+              borderColor: "divider",
+              display: "flex",
+              gap: 1,
+              "&:last-child": { borderBottom: 0 },
+            }}
+          >
+            <Chip
+              label={event.event_type}
+              size="small"
+              variant="outlined"
+              color="info"
+              sx={{ fontFamily: "inherit", fontSize: "inherit", height: 20 }}
+            />
+            <Box
+              component="span"
+              sx={{
+                overflow: "hidden",
+                textOverflow: "ellipsis",
+                whiteSpace: "nowrap",
+                color: "text.secondary",
+              }}
+            >
+              {event.attributes.join(", ")}
+            </Box>
+          </Box>
+        ))
+      )}
+    </Box>
+  );
+}
+
 function StreamDetailRow({
   stream,
   streamInfo,
@@ -161,98 +258,109 @@ function StreamDetailRow({
   return (
     <TableRow>
       <TableCell colSpan={5} sx={{ py: 0, px: 0 }}>
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: "1fr 1fr",
-            gap: 3,
-            p: 3,
-            bgcolor: "action.hover",
-          }}
-        >
-          {/* Left: About + Schema */}
-          <Box>
-            {schemaInfo && (
-              <>
-                <Typography
-                  variant="overline"
-                  color="text.secondary"
-                  sx={{ mb: 1, display: "block" }}
-                >
-                  About
-                </Typography>
-                <Typography variant="body2" sx={{ mb: 2, lineHeight: 1.7 }}>
-                  {schemaInfo.description}
-                </Typography>
-              </>
-            )}
-            <Typography
-              variant="overline"
-              color="text.secondary"
-              sx={{ mb: 1, display: "block" }}
-            >
-              Event Schema
-            </Typography>
-            {streamInfo ? (
-              <StreamSchema streamInfo={streamInfo} />
-            ) : (
-              <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
-                {stream.event_types.map((et) => (
-                  <Chip key={et} label={et} size="small" variant="outlined" />
-                ))}
-              </Box>
-            )}
-          </Box>
-
-          {/* Right: FAQ */}
-          {schemaInfo && (
+        <Box sx={{ p: 3, bgcolor: "action.hover" }}>
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 3,
+              mb: 2,
+            }}
+          >
+            {/* Left: About + Schema */}
             <Box>
+              {schemaInfo && (
+                <>
+                  <Typography
+                    variant="overline"
+                    color="text.secondary"
+                    sx={{ mb: 1, display: "block" }}
+                  >
+                    About
+                  </Typography>
+                  <Typography variant="body2" sx={{ mb: 2, lineHeight: 1.7 }}>
+                    {schemaInfo.description}
+                  </Typography>
+                </>
+              )}
               <Typography
                 variant="overline"
                 color="text.secondary"
                 sx={{ mb: 1, display: "block" }}
               >
-                FAQ
+                Event Schema
               </Typography>
-              {schemaInfo.faqs.map((item: FAQItem) => (
-                <Accordion
-                  key={item.id}
-                  disableGutters
-                  sx={{
-                    "&:before": { display: "none" },
-                    "&.Mui-expanded": { margin: "0 0 4px 0" },
-                  }}
+              {streamInfo ? (
+                <StreamSchema streamInfo={streamInfo} />
+              ) : (
+                <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                  {stream.event_types.map((et) => (
+                    <Chip key={et} label={et} size="small" variant="outlined" />
+                  ))}
+                </Box>
+              )}
+            </Box>
+
+            {/* Right: FAQ */}
+            {schemaInfo && (
+              <Box>
+                <Typography
+                  variant="overline"
+                  color="text.secondary"
+                  sx={{ mb: 1, display: "block" }}
                 >
-                  <AccordionSummary
-                    expandIcon={<ExpandMoreIcon />}
+                  FAQ
+                </Typography>
+                {schemaInfo.faqs.map((item: FAQItem) => (
+                  <Accordion
+                    key={item.id}
+                    disableGutters
                     sx={{
-                      "& .MuiAccordionSummary-content": {
-                        alignItems: "center",
-                        gap: 1,
-                      },
+                      "&:before": { display: "none" },
+                      "&.Mui-expanded": { margin: "0 0 4px 0" },
                     }}
                   >
-                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
-                      {item.question}
-                    </Typography>
-                    {item.category && (
-                      <Chip
-                        label={item.category}
-                        size="small"
-                        variant="outlined"
-                        sx={{ ml: "auto" }}
-                      />
-                    )}
-                  </AccordionSummary>
-                  <AccordionDetails>
-                    <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
-                      {item.answer}
-                    </Typography>
-                  </AccordionDetails>
-                </Accordion>
-              ))}
-            </Box>
-          )}
+                    <AccordionSummary
+                      expandIcon={<ExpandMoreIcon />}
+                      sx={{
+                        "& .MuiAccordionSummary-content": {
+                          alignItems: "center",
+                          gap: 1,
+                        },
+                      }}
+                    >
+                      <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                        {item.question}
+                      </Typography>
+                      {item.category && (
+                        <Chip
+                          label={item.category}
+                          size="small"
+                          variant="outlined"
+                          sx={{ ml: "auto" }}
+                        />
+                      )}
+                    </AccordionSummary>
+                    <AccordionDetails>
+                      <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+                        {item.answer}
+                      </Typography>
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </Box>
+            )}
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ mb: 1, display: "block" }}
+          >
+            Live Events
+          </Typography>
+          <LiveEventFeed streamName={stream.name} />
         </Box>
       </TableCell>
     </TableRow>

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -262,13 +262,14 @@ function StreamDetailRow({
         <Box sx={{ px: 2, py: 1.5, bgcolor: "action.hover" }}>
           <Box
             sx={{
-              display: "flex",
+              display: "grid",
+              gridTemplateColumns: schemaInfo ? "1fr 1fr" : "1fr",
               gap: 2,
               mb: 1,
             }}
           >
             {/* Left: About + Schema */}
-            <Box sx={{ flex: 1, minWidth: 0 }}>
+            <Box sx={{ minWidth: 0 }}>
               {schemaInfo && (
                 <>
                   <Typography
@@ -303,7 +304,7 @@ function StreamDetailRow({
 
             {/* Right: FAQ */}
             {schemaInfo && (
-              <Box sx={{ flex: 1, minWidth: 0 }}>
+              <Box sx={{ minWidth: 0 }}>
                 <Typography
                   variant="overline"
                   color="text.secondary"
@@ -486,7 +487,7 @@ function StreamsPage() {
       >
         <Container
           component="main"
-          maxWidth="lg"
+          maxWidth="xl"
           sx={{
             overflow: "auto",
             flex: "1 1 auto",

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -263,7 +263,7 @@ function StreamDetailRow({
           <Box
             sx={{
               display: "grid",
-              gridTemplateColumns: "1fr 1fr",
+              gridTemplateColumns: schemaInfo ? "1fr 1fr" : "1fr",
               gap: 2,
               mb: 1,
             }}
@@ -279,7 +279,7 @@ function StreamDetailRow({
                   >
                     About
                   </Typography>
-                  <Typography variant="body2" sx={{ mb: 2, lineHeight: 1.7 }}>
+                  <Typography variant="body2" sx={{ mb: 1, lineHeight: 1.5 }}>
                     {schemaInfo.description}
                   </Typography>
                 </>
@@ -353,7 +353,7 @@ function StreamDetailRow({
             )}
           </Box>
 
-          <Divider sx={{ my: 2 }} />
+          <Divider sx={{ my: 1 }} />
           <Typography
             variant="overline"
             color="text.secondary"

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -1,0 +1,400 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { getStreamStats, getQueryInfos, getStreamsInfo } from "@/utils/api";
+import { getSchemaInfo, type FAQItem } from "@/data/faq";
+import type { StreamInfo, StreamStats, StreamType } from "@/types";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Chip,
+  Container,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { Fragment, useState } from "react";
+
+export const Route = createFileRoute("/streams")({
+  component: StreamsPage,
+});
+
+function SummaryBar({
+  stats,
+  activeQueryCount,
+}: {
+  stats: StreamStats[];
+  activeQueryCount: number;
+}) {
+  const liveCount = stats.filter((s) => s.status === "live").length;
+  const totalEps = stats.reduce((sum, s) => sum + s.events_per_sec, 0);
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        gap: 2,
+        mb: 3,
+      }}
+    >
+      {[
+        { label: "Active Streams", value: liveCount, color: "success.main" },
+        {
+          label: "Total Events/sec",
+          value: totalEps.toFixed(1),
+          color: "info.main",
+        },
+        { label: "Active Queries", value: activeQueryCount, color: "text.primary" },
+      ].map((item) => (
+        <Paper
+          key={item.label}
+          sx={{
+            flex: 1,
+            py: 2,
+            textAlign: "center",
+          }}
+          variant="outlined"
+        >
+          <Typography
+            variant="overline"
+            color="text.secondary"
+            sx={{ fontSize: "0.65rem" }}
+          >
+            {item.label}
+          </Typography>
+          <Typography
+            variant="h4"
+            sx={{ fontWeight: 700, color: item.color }}
+          >
+            {item.value}
+          </Typography>
+        </Paper>
+      ))}
+    </Box>
+  );
+}
+
+function formatLastEvent(secondsAgo: number | null): string {
+  if (secondsAgo === null) return "Never";
+  if (secondsAgo < 1) return "< 1s ago";
+  if (secondsAgo < 60) return `${Math.round(secondsAgo)}s ago`;
+  if (secondsAgo < 3600) return `${Math.round(secondsAgo / 60)}m ago`;
+  return `${Math.round(secondsAgo / 3600)}h ago`;
+}
+
+function StatusChip({ status }: { status: StreamStats["status"] }) {
+  const config = {
+    live: { label: "Live", color: "success" as const },
+    stale: { label: "Stale", color: "warning" as const },
+    inactive: { label: "Inactive", color: "default" as const },
+  };
+  const { label, color } = config[status];
+  return <Chip label={label} color={color} size="small" variant="outlined" />;
+}
+
+const VALUE_TYPE_NAMES: Record<number, string> = {
+  0: "int",
+  1: "double",
+  2: "string",
+  3: "bool",
+};
+
+function StreamSchema({ streamInfo }: { streamInfo: StreamInfo }) {
+  return (
+    <Box
+      component="pre"
+      sx={{
+        fontFamily: '"Roboto Mono", monospace',
+        fontSize: "0.75rem",
+        bgcolor: "background.default",
+        p: 1.5,
+        borderRadius: 1,
+        border: 1,
+        borderColor: "divider",
+        overflow: "auto",
+        m: 0,
+        lineHeight: 1.8,
+      }}
+    >
+      {streamInfo.events_info.map((event, i) => (
+        <Fragment key={event.id}>
+          <Box component="span" sx={{ color: "success.main", fontWeight: 600 }}>
+            {event.name}
+          </Box>
+          {" { "}
+          {event.attributes_info.map((attr, j) => (
+            <Fragment key={attr.name}>
+              {attr.name}
+              {": "}
+              <Box component="span" sx={{ color: "info.main" }}>
+                {VALUE_TYPE_NAMES[attr.value_type] ?? String(attr.value_type)}
+              </Box>
+              {j < event.attributes_info.length - 1 ? ", " : ""}
+            </Fragment>
+          ))}
+          {" }"}
+          {i < streamInfo.events_info.length - 1 ? "\n" : ""}
+        </Fragment>
+      ))}
+    </Box>
+  );
+}
+
+function StreamDetailRow({
+  stream,
+  streamInfo,
+}: {
+  stream: StreamStats;
+  streamInfo: StreamInfo | undefined;
+}) {
+  const streamType = stream.name.toLowerCase() as StreamType;
+  const schemaInfo = getSchemaInfo(streamType);
+
+  return (
+    <TableRow>
+      <TableCell colSpan={5} sx={{ py: 0, px: 0 }}>
+        <Box
+          sx={{
+            display: "grid",
+            gridTemplateColumns: "1fr 1fr",
+            gap: 3,
+            p: 3,
+            bgcolor: "action.hover",
+          }}
+        >
+          {/* Left: About + Schema */}
+          <Box>
+            {schemaInfo && (
+              <>
+                <Typography
+                  variant="overline"
+                  color="text.secondary"
+                  sx={{ mb: 1, display: "block" }}
+                >
+                  About
+                </Typography>
+                <Typography variant="body2" sx={{ mb: 2, lineHeight: 1.7 }}>
+                  {schemaInfo.description}
+                </Typography>
+              </>
+            )}
+            <Typography
+              variant="overline"
+              color="text.secondary"
+              sx={{ mb: 1, display: "block" }}
+            >
+              Event Schema
+            </Typography>
+            {streamInfo ? (
+              <StreamSchema streamInfo={streamInfo} />
+            ) : (
+              <Box sx={{ display: "flex", gap: 1, flexWrap: "wrap" }}>
+                {stream.event_types.map((et) => (
+                  <Chip key={et} label={et} size="small" variant="outlined" />
+                ))}
+              </Box>
+            )}
+          </Box>
+
+          {/* Right: FAQ */}
+          {schemaInfo && (
+            <Box>
+              <Typography
+                variant="overline"
+                color="text.secondary"
+                sx={{ mb: 1, display: "block" }}
+              >
+                FAQ
+              </Typography>
+              {schemaInfo.faqs.map((item: FAQItem) => (
+                <Accordion
+                  key={item.id}
+                  disableGutters
+                  sx={{
+                    "&:before": { display: "none" },
+                    "&.Mui-expanded": { margin: "0 0 4px 0" },
+                  }}
+                >
+                  <AccordionSummary
+                    expandIcon={<ExpandMoreIcon />}
+                    sx={{
+                      "& .MuiAccordionSummary-content": {
+                        alignItems: "center",
+                        gap: 1,
+                      },
+                    }}
+                  >
+                    <Typography variant="body2" sx={{ fontWeight: 500 }}>
+                      {item.question}
+                    </Typography>
+                    {item.category && (
+                      <Chip
+                        label={item.category}
+                        size="small"
+                        variant="outlined"
+                        sx={{ ml: "auto" }}
+                      />
+                    )}
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <Typography variant="body2" sx={{ lineHeight: 1.6 }}>
+                      {item.answer}
+                    </Typography>
+                  </AccordionDetails>
+                </Accordion>
+              ))}
+            </Box>
+          )}
+        </Box>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function StreamTable({
+  stats,
+  streamsInfo,
+}: {
+  stats: StreamStats[];
+  streamsInfo: StreamInfo[];
+}) {
+  const [expandedStream, setExpandedStream] = useState<string | null>(null);
+
+  const handleRowClick = (name: string) => {
+    setExpandedStream((prev) => (prev === name ? null : name));
+  };
+
+  return (
+    <TableContainer component={Paper} variant="outlined">
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Stream</TableCell>
+            <TableCell align="right">Events/sec</TableCell>
+            <TableCell align="right">Total Events</TableCell>
+            <TableCell align="right">Last Event</TableCell>
+            <TableCell align="center">Status</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {stats.map((stream) => (
+            <Fragment key={stream.name}>
+              <TableRow
+                hover
+                onClick={() => handleRowClick(stream.name)}
+                sx={{
+                  cursor: "pointer",
+                  "& > *": {
+                    borderBottom:
+                      expandedStream === stream.name ? 0 : undefined,
+                  },
+                }}
+              >
+                <TableCell>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    {expandedStream === stream.name ? "▾" : "▸"}{" "}
+                    {stream.name.charAt(0).toUpperCase() + stream.name.slice(1)}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: 600, color: "info.main" }}
+                  >
+                    {stream.events_per_sec}
+                  </Typography>
+                </TableCell>
+                <TableCell align="right">
+                  {stream.total_events.toLocaleString()}
+                </TableCell>
+                <TableCell align="right">
+                  {formatLastEvent(stream.last_event_seconds_ago)}
+                </TableCell>
+                <TableCell align="center">
+                  <StatusChip status={stream.status} />
+                </TableCell>
+              </TableRow>
+              {expandedStream === stream.name && (
+                <StreamDetailRow
+                  stream={stream}
+                  streamInfo={streamsInfo.find(
+                    (si) =>
+                      si.name.toLowerCase() === stream.name.toLowerCase(),
+                  )}
+                />
+              )}
+            </Fragment>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function StreamsPage() {
+  const { data: stats = [] } = useQuery({
+    queryKey: ["streamStats"],
+    queryFn: getStreamStats,
+    refetchInterval: 2000,
+  });
+
+  const { data: queries = new Map() } = useQuery({
+    queryKey: ["queries"],
+    queryFn: getQueryInfos,
+    refetchInterval: 2000,
+  });
+
+  const { data: streamsInfo = [] } = useQuery({
+    queryKey: ["streams"],
+    queryFn: getStreamsInfo,
+    refetchInterval: 10000,
+  });
+
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+      }}
+    >
+      <Box
+        sx={{
+          flex: "1 1 auto",
+          minHeight: 0,
+          display: "flex",
+          flexDirection: "column",
+          py: 3,
+        }}
+      >
+        <Container
+          component="main"
+          maxWidth="lg"
+          sx={{
+            overflow: "auto",
+            flex: "1 1 auto",
+            minHeight: 0,
+          }}
+        >
+          <Typography
+            variant="h4"
+            component="h1"
+            gutterBottom
+            sx={{ mb: 3, fontWeight: 500 }}
+          >
+            Streams
+          </Typography>
+          <SummaryBar stats={stats} activeQueryCount={queries.size} />
+          <StreamTable stats={stats} streamsInfo={streamsInfo} />
+        </Container>
+      </Box>
+    </Box>
+  );
+}

--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -51,7 +51,11 @@ function SummaryBar({
           value: totalEps.toFixed(1),
           color: "info.main",
         },
-        { label: "Active Queries", value: activeQueryCount, color: "text.primary" },
+        {
+          label: "Active Queries",
+          value: activeQueryCount,
+          color: "text.primary",
+        },
       ].map((item) => (
         <Paper
           key={item.label}
@@ -69,10 +73,7 @@ function SummaryBar({
           >
             {item.label}
           </Typography>
-          <Typography
-            variant="h4"
-            sx={{ fontWeight: 700, color: item.color }}
-          >
+          <Typography variant="h4" sx={{ fontWeight: 700, color: item.color }}>
             {item.value}
           </Typography>
         </Paper>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,3 +120,13 @@ export type TimelineConfig = {
   timeHorizonSeconds: number;
   maxEventsPerQuery: number;
 };
+
+// Stream Stats Types
+export type StreamStats = {
+  name: string;
+  events_per_sec: number;
+  total_events: number;
+  last_event_seconds_ago: number | null;
+  status: "live" | "stale" | "inactive";
+  event_types: string[];
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -4,6 +4,7 @@ import type {
   QueryInfo,
   StreamId,
   StreamInfo,
+  StreamStats,
 } from "@/types";
 import { CreateQuerySchema, GetQueryInfoSchema } from "@/schemas/querySchema";
 import { GetStreamInfoSchema } from "@/schemas/streamInfoSchema";
@@ -126,3 +127,14 @@ export const addQuery = async ({
     throw new Error(await res.text());
   }
 };
+
+export async function getStreamStats(): Promise<StreamStats[]> {
+  const baseUrl = getApiBaseUrl();
+  const fetchRes = await fetch(baseUrl + "/stream/stats", {
+    method: "GET",
+  });
+  if (!fetchRes.ok) {
+    throw new Error("Failed to fetch stream stats");
+  }
+  return (await fetchRes.json()) as StreamStats[];
+}


### PR DESCRIPTION
## Summary
- New `/streams` route with system health dashboard
- Summary bar showing active streams, total events/sec, active queries
- Stream table with live stats (events/sec, total, last event, status) polled every 2s
- Clickable rows expand inline to show stream description, full event schema with types, and stream-specific FAQ
- "Streams" entry added to navigation drawer

## Test plan
- [ ] Start backend and frontend dev servers
- [ ] Navigate to `/streams` — verify summary bar shows live data
- [ ] Verify stats update every 2 seconds
- [ ] Click a stream row — verify it expands showing About, Event Schema, and FAQ
- [ ] Click FAQ items — verify accordions expand with answers
- [ ] Verify sidebar drawer shows "Streams" between "Watch" and "Help & FAQ"
- [ ] Navigate to `/` and `/watch` — verify existing pages still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **Streams** page with live stream summaries, a summary bar, per-stream metrics, and expandable rows.
  * Expanded stream details now show event schema (when available) and event type chips; also includes **About** and **FAQ** sections when provided.
  * Added a **Streams** entry to the main navigation and enabled direct access via its own URL.
  * Introduced stream stats data support for the page’s UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->