### PR TITLE
fix: use /ws prefix for stream events WebSocket URL

### DIFF
--- a/src/routes/streams.tsx
+++ b/src/routes/streams.tsx
@@ -167,7 +167,7 @@ function LiveEventFeed({ streamName }: { streamName: string }) {
   const wsRef = useRef<WebSocket | null>(null);
 
   useEffect(() => {
-    const wsUrl = getWsBaseUrl() + "/stream/events/" + streamName;
+    const wsUrl = getWsBaseUrl() + "/ws/stream/events/" + streamName;
     const ws = new WebSocket(wsUrl);
     wsRef.current = ws;
 


### PR DESCRIPTION
## Summary
- Fix WebSocket URL to use `/ws/stream/events/{name}` instead of `/stream/events/{name}`
- Matches the backend change in CORE-cer/core-python-backend#2 and the reverse proxy config

## Test plan
- [ ] Expand a stream row — live events should connect and show data